### PR TITLE
API methods and collection for question attempts

### DIFF
--- a/client/css/components/manage_session.scss
+++ b/client/css/components/manage_session.scss
@@ -30,6 +30,13 @@
         bottom: 0;
       }
 
+      .bottom-group {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        padding: 10px;
+      }
+
     }
     
     .ql-main-content {

--- a/client/css/components/manage_session.scss
+++ b/client/css/components/manage_session.scss
@@ -1,22 +1,44 @@
 
 .ql-manage-session {
-  max-width: 1170px;
 
-  .sidebar-container {
-    position: relative;
-  }
-
-  .ql-session-sidebar {
-    background: white;
-    border-right: 1px solid #ddd;
+  .ql-row-container {
+    top: 50px;
+    left: 0;
+    position: absolute;
     height: calc(100vh - 50px);
-    padding: 20px;
+    width: 100%;
 
-    #sidebar-tabs {
+    .sidebar-container {
       position: absolute;
-      bottom: 0;
+      height: calc(100vh - 50px);
+      left: 0;
+      top: 0;
     }
 
+    .ql-session-sidebar {
+      background: white;
+      border-right: 1px solid #ddd;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 370px;
+      height: calc(100vh - 50px);
+      padding: 20px;
+
+      #sidebar-tabs {
+        position: absolute;
+        bottom: 0;
+      }
+
+    }
+    
+    .ql-main-content {
+      margin-left: 370px;
+      padding: 20px;
+      overflow: auto;
+      height: calc(100vh - 50px);
+      max-width: 1000px;
+    }
   }
 
   .ql-session-child-container {
@@ -42,7 +64,8 @@
 
   .ql-question-preview {
     border: 1px solid #ccc;
-    padding: 10px 0px 
+    padding: 10px 0px;
+    max-width: 700px;
   }
 
 }

--- a/client/css/components/manage_session.scss
+++ b/client/css/components/manage_session.scss
@@ -21,7 +21,7 @@
       position: absolute;
       top: 0;
       left: 0;
-      width: 370px;
+      width: 360px;
       height: calc(100vh - 50px);
       padding: 20px;
 
@@ -33,7 +33,7 @@
     }
     
     .ql-main-content {
-      margin-left: 370px;
+      margin-left: 360px;
       padding: 20px;
       overflow: auto;
       height: calc(100vh - 50px);
@@ -46,7 +46,8 @@
     border: 1px solid #ddd;
     padding: 18px;
     width: 100%;
-    margin: 10px;
+    margin-top: 10px;
+    margin-bottom: 10px;
 
     .ql-header-text-input {
       width: 100%;

--- a/client/css/main.scss
+++ b/client/css/main.scss
@@ -206,3 +206,7 @@ $incorrect-color: #A72526;
 .clear {
   clear: both;
 }
+
+.m-margin-top {
+  margin-top: 10px;
+}

--- a/client/css/main.scss
+++ b/client/css/main.scss
@@ -195,3 +195,14 @@ $incorrect-color: #A72526;
     margin:0;
   }
 }
+
+.ql-answer-distribution {
+  display: inline-block;
+  float: left;
+  background: white;
+  border: 1px solid #ccc;
+}
+
+.clear {
+  clear: both;
+}

--- a/imports/api/answers.js
+++ b/imports/api/answers.js
@@ -1,0 +1,93 @@
+/* global FS */
+// QLICKER
+// Author: Enoch T <me@enocht.am>
+//
+// sessions.js: JS related to course collection
+
+import { Meteor } from 'meteor/meteor'
+import { Mongo } from 'meteor/mongo'
+import { check, Match } from 'meteor/check'
+
+import { Courses } from './courses'
+import { Sessions } from './sessions'
+import { Questions } from './questions'
+
+import { _ } from 'underscore'
+import dl from 'datalib'
+
+import Helpers from './helpers.js'
+import { QUESTION_TYPE, TF_ORDER, MC_ORDER } from '../configs'
+
+// expected collection pattern
+const answerPattern = {
+  _id: Match.Maybe(Helpers.MongoID),
+  attempt: Number,
+  questionId: Helpers.MongoID,
+  studentUserId: Helpers.MongoID,
+  answer: Helpers.AnswerItem,
+  createdAt: Date
+}
+
+// Create Answer class
+const Answer = function (doc) { _.extend(this, doc) }
+_.extend(Answer.prototype, {})
+
+// Create answers collection
+export const Answers = new Mongo.Collection('answers',
+  { transform: (doc) => { return new Answer(doc) } })
+
+// data publishing
+if (Meteor.isServer) {
+  // questions in a specific question
+  Meteor.publish('answers.forQuestion', function (questionId) {
+    if (this.userId) {
+      const user = Meteor.users.findOne({ _id: this.userId })
+      const question = Questions.findOne({ _id: questionId })
+      const session = Sessions.findOne({ _id: question.sessionId })
+      const course = Courses.findOne({ _id: session.courseId })
+
+      if (user.hasRole('professor') && course.owner === this.userId) {
+        return Answers.find({ questionId: questionId })
+      } else if (user.hasRole('student')) {
+        return Answers.find({ questionId: questionId, studentUserId: this.userId })
+      }
+    } else this.ready()
+  })
+}
+
+// data methods
+Meteor.methods({
+
+  /**
+   * answer.addQuestionAnswer(Answer answerObject)
+   * add a student result to question (that is attached to session)
+   */
+  'answer.addQuestionAnswer' (answerObject) {
+    answerObject.createdAt = new Date()
+    check(answerObject, answerPattern)
+
+    const q = Questions.findOne({ _id: answerObject.questionId })
+    if (!q.sessionId) throw Error('Question not attached to session')
+    if (Meteor.userId() !== answerObject.studentUserId) throw Error('Cannot submit answer')
+
+    const c = Answers.find({
+      attempt: answerObject.attempt,
+      questionId: answerObject.questionId,
+      studentUserId: answerObject.studentUserId
+    }).count()
+    if (c > 0) return Meteor.call('answer.update', answerObject)
+
+    return Answers.insert(answerObject)
+  },
+
+  'answer.update' (answerObject) {
+    check(answerObject, answerPattern)
+
+    return Answers.update({
+      attempt: answerObject.attempt,
+      questionId: answerObject.questionId,
+      studentUserId: answerObject.studentUserId
+    }, { $set: { answer: answerObject.answer } })
+  }
+
+}) // end Meteor.methods

--- a/imports/api/answers.js
+++ b/imports/api/answers.js
@@ -70,6 +70,8 @@ Meteor.methods({
     if (!q.sessionId) throw Error('Question not attached to session')
     if (Meteor.userId() !== answerObject.studentUserId) throw Error('Cannot submit answer')
 
+    // TODO check if attempt number is current in question
+
     const c = Answers.find({
       attempt: answerObject.attempt,
       questionId: answerObject.questionId,

--- a/imports/api/questions.tests.js
+++ b/imports/api/questions.tests.js
@@ -27,7 +27,7 @@ export const sampleQuestion = {
   plainText: 'Test question?',
   content: exContentState,
   type: QUESTION_TYPE.MC,
-  answers: [{ wysiwyg: true, correct: false, answer: 'A', content: exContentState, plainText: 'Test question?' }],
+  options: [{ wysiwyg: true, correct: false, answer: 'A', content: exContentState, plainText: 'Test question?' }],
   submittedBy: '',
   tags: []
 }

--- a/imports/api/sessions.js
+++ b/imports/api/sessions.js
@@ -84,6 +84,9 @@ Meteor.methods({
 
     profHasCoursePermission(session.courseId)
 
+    if (session.status === 'running') Meteor.call('sessions.startSession', session._id)
+    else Meteor.call('sessions.endSession', session._id)
+
     return Sessions.update({ _id: session._id }, {
       $set: {
         name: session.name,
@@ -149,7 +152,8 @@ Meteor.methods({
    * mark session as active and set first question to current
    */
   'sessions.startSession' (sessionId) {
-
+    const s = Sessions.findOne({ _id: sessionId })
+    return Sessions.update({ _id: sessionId }, { $set: { currentQuestion: s.questions[0] } })
   },
 
   /**
@@ -157,7 +161,7 @@ Meteor.methods({
    * mark session as done and clear currentQuestion
    */
   'sessions.endSession' (sessionId) {
-
+    return Sessions.update({ _id: sessionId }, { $unset: { currentQuestion: '' } })
   },
 
   /**

--- a/imports/ui/AnswerDistribution.jsx
+++ b/imports/ui/AnswerDistribution.jsx
@@ -33,7 +33,7 @@ export class _AnswerDistribution extends Component {
     })
     return (<div>
       <BarChart className='ql-answer-distribution'
-        height={200} width={600} data={this.props.distribution}
+        height={190} width={600} data={this.props.distribution}
         margin={{top: 10, right: 10, left: -25, bottom: 5}}>
         <XAxis dataKey='answer' />
         <YAxis allowDecimals={false} />

--- a/imports/ui/AnswerDistribution.jsx
+++ b/imports/ui/AnswerDistribution.jsx
@@ -8,43 +8,82 @@ import { createContainer } from 'meteor/react-meteor-data'
 import { _ } from 'underscore'
 
 import dl from 'datalib'
-import { BarChart, Bar, XAxis, YAxis } from 'recharts'
+import { BarChart, Bar, XAxis, YAxis, Legend } from 'recharts'
 
 import { Answers } from '../api/answers'
-
+import { QUESTION_TYPE, TF_ORDER, MC_ORDER } from '../configs'
 
 export class _AnswerDistribution extends Component {
 
+  getRandomColor () {
+    let letters = '0123456789ABCDEF'
+    let color = '#'
+    for (let i = 0; i < 6; i++) {
+      color += letters[Math.floor(Math.random() * 16)]
+    }
+    return color
+  }
+
   render () {
+    const colorSeq = ['#2FB0E8', '#FFC32A', '#27EE77', '#FF532A']
+    const bars = []
+    _(this.props.maxAttempt).times((i) => {
+      const color = colorSeq[i] || this.getRandomColor()
+      bars.push(<Bar dataKey={'attempt_' + (i + 1)} maxBarSize={45} fill={color} label isAnimationActive={false} />)
+    })
     return (<div>
-      <BarChart
-        width={400} height={200} data={this.props.distribution}
-        margin={{top: 5, right: 0, left: -20, bottom: 5}}>
+      <BarChart className='ql-answer-distribution'
+        height={200} width={600} data={this.props.distribution}
+        margin={{top: 10, right: 10, left: -25, bottom: 5}}>
         <XAxis dataKey='answer' />
         <YAxis allowDecimals={false} />
-        <Bar dataKey='count' fill='#2FB0E8' label isAnimationActive={false} />
+        <Legend />
+        {bars}
       </BarChart>
     </div>)
   } //  end render
 
 }
 
-
 export const AnswerDistribution = createContainer((props) => {
   const handle = Meteor.subscribe('answers.forQuestion', props.question._id)
+  const answers = Answers.find({ questionId: props.question._id }).fetch()
 
-  const answers = Answers.find({ questionId: props.question._id, attempt: props.attempt }).fetch()
-  const aggr = dl.groupby('answer').count().execute(answers)
+  const maxAttempt = props.question.sessionOptions.attempts.length
+  const validOptions = _(props.question.options).pluck('answer')
+
+  const data = []
+  let options = _(dl.groupby('answer').execute(answers)).sortBy('answer')
+  options.map((a) => {
+    a.counts = _(dl.groupby('attempt').count().execute(a.values)).sortBy('attempt')
+    delete a.values
+  })
+  options = _(options).indexBy('answer')
+
+  validOptions.forEach((key) => {
+    if (key in options) {
+      const counts = _(options[key].counts).indexBy('attempt')
+      _(maxAttempt).times((i) => {
+        options[key]['attempt_' + (i + 1)] = counts[i + 1] ? counts[i + 1].count : 0
+      })
+    } else {
+      _(maxAttempt).times((i) => {
+        if (!(key in options)) options[key] = { answer: key }
+        options[key]['attempt_' + (i + 1)] = 0
+      })
+    }
+    data.push(options[key])
+  })
 
   return {
     answers: answers,
-    distribution: _(aggr).sortBy('answer'),
+    distribution: data,
+    maxAttempt: maxAttempt,
     loading: !handle.ready()
   }
 }, _AnswerDistribution)
 
 AnswerDistribution.propTypes = {
-  question: PropTypes.object.isRequired,
-  attempt: PropTypes.number.isRequired
+  question: PropTypes.object.isRequired
 }
 

--- a/imports/ui/AnswerDistribution.jsx
+++ b/imports/ui/AnswerDistribution.jsx
@@ -1,0 +1,50 @@
+// QLICKER
+// Author: Enoch T <me@enocht.am>
+//
+// QuestionStats.jsx: Component for attempt distributions for a question
+
+import React, { Component, PropTypes } from 'react'
+import { createContainer } from 'meteor/react-meteor-data'
+import { _ } from 'underscore'
+
+import dl from 'datalib'
+import { BarChart, Bar, XAxis, YAxis } from 'recharts'
+
+import { Answers } from '../api/answers'
+
+
+export class _AnswerDistribution extends Component {
+
+  render () {
+    return (<div>
+      <BarChart
+        width={400} height={200} data={this.props.distribution}
+        margin={{top: 5, right: 0, left: -20, bottom: 5}}>
+        <XAxis dataKey='answer' />
+        <YAxis allowDecimals={false} />
+        <Bar dataKey='count' fill='#2FB0E8' label isAnimationActive={false} />
+      </BarChart>
+    </div>)
+  } //  end render
+
+}
+
+
+export const AnswerDistribution = createContainer((props) => {
+  const handle = Meteor.subscribe('answers.forQuestion', props.question._id)
+
+  const answers = Answers.find({ questionId: props.question._id, attempt: props.attempt }).fetch()
+  const aggr = dl.groupby('answer').count().execute(answers)
+
+  return {
+    answers: answers,
+    distribution: _(aggr).sortBy('answer'),
+    loading: !handle.ready()
+  }
+}, _AnswerDistribution)
+
+AnswerDistribution.propTypes = {
+  question: PropTypes.object.isRequired,
+  attempt: PropTypes.number.isRequired
+}
+

--- a/imports/ui/QuestionDisplay.jsx
+++ b/imports/ui/QuestionDisplay.jsx
@@ -13,27 +13,8 @@ export class QuestionDisplay extends Component {
   constructor (p) {
     super(p)
 
-    this.submitAnswer = this.submitAnswer.bind(this)
-
     this.readonly = false
     if (this.props.readonly) this.readonly = this.props.readonly
-  }
-
-  submitAnswer (answer) {
-    const answerObject = {
-      studentUserId: Meteor.userId(),
-      answer: answer,
-      attempt: this.props.attempt.number,
-      questionId: this.props.question._id
-    }
-    Meteor.call('answer.addQuestionAnswer', answerObject, (err, answerId) => {
-      if (err) {
-        alertify.error('Error: ' + err.error)
-      } else {
-        alertify.success('Answer Submitted')
-        // success. do stuff here if needed
-      }
-    })
   }
 
   componentDidMount () {
@@ -54,15 +35,15 @@ export class QuestionDisplay extends Component {
 
       <div className='ql-answers'>
         {
-          q.options.map((a) => {
+          q.answers.map((a) => {
             let content
 
             if (a.wysiwyg) {
-              content = (<div onClick={() => this.submitAnswer(a.answer)} className='ql-wysiwyg-content' key={'answer_' + a.answer}>
+              content = (<div className='ql-wysiwyg-content' key={'answer_' + a.answer}>
                 { WysiwygHelper.htmlDiv(a.content) }
               </div>)
             } else {
-              content = (<div onClick={() => this.submitAnswer(a.answer)} className='ql-tf-content' key={'answer_' + a.answer}>
+              content = (<div className='ql-tf-content' key={'answer_' + a.answer}>
                 <span className={a.answer === 'TRUE' ? 'correct-color' : 'incorrect-color'}>{a.answer}</span>
               </div>)
             }

--- a/imports/ui/QuestionDisplay.jsx
+++ b/imports/ui/QuestionDisplay.jsx
@@ -13,8 +13,27 @@ export class QuestionDisplay extends Component {
   constructor (p) {
     super(p)
 
+    this.submitAnswer = this.submitAnswer.bind(this)
+
     this.readonly = false
     if (this.props.readonly) this.readonly = this.props.readonly
+  }
+
+  submitAnswer (answer) {
+    const answerObject = {
+      studentUserId: Meteor.userId(),
+      answer: answer,
+      attempt: 1,
+      questionId: this.props.question._id
+    }
+    Meteor.call('answer.addQuestionAnswer', answerObject, (err, answerId) => {
+      if (err) {
+        alertify.error('Error: ' + err.error)
+      } else {
+        alertify.success('Answer Submitted')
+        // success. do stuff here if needed
+      }
+    })
   }
 
   componentDidMount () {
@@ -35,15 +54,15 @@ export class QuestionDisplay extends Component {
 
       <div className='ql-answers'>
         {
-          q.answers.map((a) => {
+          q.options.map((a) => {
             let content
 
             if (a.wysiwyg) {
-              content = (<div className='ql-wysiwyg-content' key={'answer_' + a.answer}>
+              content = (<div onClick={() => this.submitAnswer(a.answer)} className='ql-wysiwyg-content' key={'answer_' + a.answer}>
                 { WysiwygHelper.htmlDiv(a.content) }
               </div>)
             } else {
-              content = (<div className='ql-tf-content' key={'answer_' + a.answer}>
+              content = (<div onClick={() => this.submitAnswer(a.answer)} className='ql-tf-content' key={'answer_' + a.answer}>
                 <span className={a.answer === 'TRUE' ? 'correct-color' : 'incorrect-color'}>{a.answer}</span>
               </div>)
             }

--- a/imports/ui/QuestionDisplay.jsx
+++ b/imports/ui/QuestionDisplay.jsx
@@ -23,7 +23,7 @@ export class QuestionDisplay extends Component {
     const answerObject = {
       studentUserId: Meteor.userId(),
       answer: answer,
-      attempt: 1,
+      attempt: this.props.attempt.number,
       questionId: this.props.question._id
     }
     Meteor.call('answer.addQuestionAnswer', answerObject, (err, answerId) => {

--- a/imports/ui/QuestionEditItem.jsx
+++ b/imports/ui/QuestionEditItem.jsx
@@ -40,7 +40,7 @@ export class QuestionEditItem extends Component {
     this.addTag = this.addTag.bind(this)
     this.handleDrag = this.handleDrag.bind(this)
     this.changeType = this.changeType.bind(this)
-    this._DB_saveQuestion = _.debounce(this.saveQuestion, 2500)
+    this._DB_saveQuestion = _.debounce(this.saveQuestion, 2000)
 
     // if editing pre-exsiting question
     if (this.props.question) {

--- a/imports/ui/QuestionEditItem.jsx
+++ b/imports/ui/QuestionEditItem.jsx
@@ -20,7 +20,7 @@ export const DEFAULT_STATE = {
   plainText: '',
   type: -1, // QUESTION_TYPE.MC, QUESTION_TYPE.TF, QUESTION_TYPE.SA
   content: null,
-  answers: [], // { correct: false, answer: 'A', content: editor content }
+  options: [], // { correct: false, answer: 'A', content: editor content }
   submittedBy: '',
   tags: []
 }
@@ -34,7 +34,7 @@ export class QuestionEditItem extends Component {
     this.onEditorStateChange = this.onEditorStateChange.bind(this)
     this.uploadImageCallBack = this.uploadImageCallBack.bind(this)
     this.addAnswer = this.addAnswer.bind(this)
-    this.setAnswerState = this.setAnswerState.bind(this)
+    this.setOptionState = this.setOptionState.bind(this)
     this.markCorrect = this.markCorrect.bind(this)
     this.deleteTag = this.deleteTag.bind(this)
     this.addTag = this.addTag.bind(this)
@@ -46,7 +46,7 @@ export class QuestionEditItem extends Component {
     if (this.props.question) {
       this.state = _.extend({}, this.props.question)
 
-      this.currentAnswer = this.state.answers.length
+      this.currentAnswer = this.state.options.length
       switch (this.state.type) {
         case QUESTION_TYPE.MC:
           this.answerOrder = MC_ORDER
@@ -82,7 +82,7 @@ export class QuestionEditItem extends Component {
   changeType (newValue) {
     let type = parseInt(newValue)
 
-    this.setState({ type: type, answers: [] }, () => {
+    this.setState({ type: type, options: [] }, () => {
       if (type === QUESTION_TYPE.MC) {
         this.currentAnswer = 0
         this.answerOrder = _.extend({}, MC_ORDER)
@@ -151,18 +151,18 @@ export class QuestionEditItem extends Component {
   }
 
   /**
-   * setAnswerState(String: answerKey, Object: content)
+   * setOptionState(String: answerKey, Object: content)
    * Update wysiwyg content in the state based on the answer
    */
-  setAnswerState (answerKey, content, plainText) {
-    let answers = this.state.answers
-    const i = _(answers).findIndex({ answer: answerKey })
-    answers[i].content = content
-    answers[i].plainText = plainText
-    this.setState({ answers: answers }, () => {
+  setOptionState (answerKey, content, plainText) {
+    let options = this.state.options
+    const i = _(options).findIndex({ answer: answerKey })
+    options[i].content = content
+    options[i].plainText = plainText
+    this.setState({ options: options }, () => {
       this._DB_saveQuestion()
     })
-  } // end setAnswerState
+  } // end setOptionState
 
   /**
    * addAnswer(Event _, Event e, Boolean wysiwyg, Callback done = null)
@@ -172,7 +172,7 @@ export class QuestionEditItem extends Component {
     const answerKey = this.answerOrder[this.currentAnswer]
     if (this.currentAnswer >= this.answerOrder.length) return
     this.setState({
-      answers: this.state.answers.concat([{
+      options: this.state.options.concat([{
         correct: this.currentAnswer === 0,
         answer: answerKey,
         wysiwyg: wysiwyg
@@ -180,8 +180,8 @@ export class QuestionEditItem extends Component {
     }, () => {
       this.currentAnswer++
 
-      if (wysiwyg) this.setAnswerState(answerKey, '', '')
-      else this.setAnswerState(answerKey, answerKey, answerKey)
+      if (wysiwyg) this.setOptionState(answerKey, '', '')
+      else this.setOptionState(answerKey, answerKey, answerKey)
 
       if (done) done()
     })
@@ -192,20 +192,20 @@ export class QuestionEditItem extends Component {
    * Set answer as correct in stae
    */
   markCorrect (answerKey) {
-    let answers = this.state.answers
+    let options = this.state.options
 
     if (this.state.type === QUESTION_TYPE.MS) {
-      answers.forEach((a, i) => {
-        if (a.answer === answerKey) answers[i].correct = !answers[i].correct
+      options.forEach((a, i) => {
+        if (a.answer === answerKey) options[i].correct = !options[i].correct
       })
     } else {
-      answers.forEach((a, i) => {
-        if (a.answer === answerKey) answers[i].correct = true
-        else answers[i].correct = false
+      options.forEach((a, i) => {
+        if (a.answer === answerKey) options[i].correct = true
+        else options[i].correct = false
       })
     }
 
-    this.setState({ answers: answers}, () => {
+    this.setState({ options: options }, () => {
       this._DB_saveQuestion()
     })
   }
@@ -217,7 +217,7 @@ export class QuestionEditItem extends Component {
   saveQuestion () {
     let question = _.extend({ createdAt: new Date() }, this.state)
 
-    if (question.answers.length === 0 && question.type !== QUESTION_TYPE.SA) return
+    if (question.options.length === 0 && question.type !== QUESTION_TYPE.SA) return
 
     if (this.props.sessionId) question.sessionId = this.props.sessionId
     if (this.props.courseId) question.courseId = this.props.courseId
@@ -266,7 +266,7 @@ export class QuestionEditItem extends Component {
   render () {
     const answerEditor = (a) => {
       const changeHandler = (content, plainText) => {
-        this.setAnswerState(a.answer, content, plainText)
+        this.setOptionState(a.answer, content, plainText)
       }
 
       const wysiwygAnswer = (
@@ -297,10 +297,10 @@ export class QuestionEditItem extends Component {
 
     // generate rows with up to 2 editors on each row
     let editorRows = []
-    const len = this.state.answers.length
+    const len = this.state.options.length
     for (let i = 0; i < len; i = i + 2) {
-      let gaurunteed = this.state.answers[i]
-      let possiblyUndefined = i < len ? this.state.answers[i + 1] : undefined
+      let gaurunteed = this.state.options[i]
+      let possiblyUndefined = i < len ? this.state.options[i + 1] : undefined
 
       editorRows.push(<div key={'row_' + i + '-' + i + 1} className='row'>
         { answerEditor(gaurunteed) }

--- a/imports/ui/pages/page_container.jsx
+++ b/imports/ui/pages/page_container.jsx
@@ -14,6 +14,8 @@ class _PageContainer extends Component {
     super(props)
     this.state = {}
     this.state.user = Meteor.user() || this.props.user
+
+    alertify.logPosition('bottom right')
   }
 
   render () {
@@ -24,7 +26,9 @@ class _PageContainer extends Component {
 
     const homePath = Router.routes[this.state.user.profile.roles[0]].path()
     const questionsPage = Router.routes['questions'].path()
-    const coursesPage = Router.routes['courses'].path()
+    const coursesPage = this.state.user.hasRole('professor')
+      ? Router.routes['courses'].path()
+      : Router.routes['student'].path()
     return (
       <div className='ql-page-container'>
         <nav className='navbar navbar-default navbar-fixed-top'>
@@ -53,7 +57,11 @@ class _PageContainer extends Component {
                     }
                   </ul>
                 </li>
-                <li><a className='bootstrap-overrides' href={questionsPage}>Questions</a></li>
+                {
+                  this.state.user.hasRole('professor')
+                    ? <li><a className='bootstrap-overrides' href={questionsPage}>Questions</a></li>
+                    : ''
+                }
                 <li><a className='bootstrap-overrides' href='#'>Grades</a></li>
               </ul>
 
@@ -85,7 +93,7 @@ export const PageContainer = createContainer(() => {
   const handle = Meteor.subscribe('courses')
 
   return {
-    courses: Courses.find({ owner: Meteor.userId() }).fetch(),
+    courses: Courses.find({}).fetch(),
     loading: !handle.ready()
   }
 }, _PageContainer)

--- a/imports/ui/pages/professor/manage_session.jsx
+++ b/imports/ui/pages/professor/manage_session.jsx
@@ -164,10 +164,10 @@ class _ManageSession extends Component {
     })
 
     return (
-      <div className='container-fluid ql-manage-session'>
+      <div className='ql-manage-session'>
 
-        <div className='row'>
-          <div className='col-md-4 col-sm-4 sidebar-container'>
+        <div className='ql-row-container'>
+          <div className='ql-sidebar-container'>
             <div className='ql-session-sidebar'>
               <div className='tab-content'>
                 <div role='tabpanel' className='tab-pane active' id='session'>
@@ -195,7 +195,7 @@ class _ManageSession extends Component {
               </ul>
             </div>
           </div>
-          <div className='col-md-8 col-sm-8' >
+          <div className='ql-main-content' >
 
             <div className='ql-session-child-container'>
               <input type='text' className='ql-header-text-input' value={this.state.session.name} onChange={this.setSessionName} />

--- a/imports/ui/pages/professor/run_session.jsx
+++ b/imports/ui/pages/professor/run_session.jsx
@@ -186,6 +186,8 @@ class _RunSession extends Component {
     const strAttemptEnabled = currentAttempt.closed
       ? 'Allow Answers' : 'Disallow Answers'
 
+    // small methods
+    const secondDisplay = () => { window.open('/session/present/' + this.state.session._id, 'Qlicker', 'height=768,width=1024') }
     return (
       <div className='ql-manage-session'>
 
@@ -194,8 +196,8 @@ class _RunSession extends Component {
             <div className='ql-session-sidebar'>
               <h2>Session: { this.state.session.name }</h2>
               <div className='btn-group btn-group-justified' role='group'>
-                <a href='#' className='btn btn-default btn-sm'>Presentation Mode</a>
-                <a href='#' className='btn btn-default btn-sm' onClick={() => { window.open('/session/present/' + this.state.session._id, 'Qlicker', 'height=768,width=1024') }}>Seperate Question Display</a>
+                <a href='#' className='btn btn-default btn-sm'>Presentation Mode <span className='glyphicon glyphicon-fullscreen' /></a>
+                <a href='#' className='btn btn-default btn-sm' onClick={secondDisplay}>2nd Display <span className='glyphicon glyphicon-blackboard' /></a>
               </div>
               <hr />
               <h3>Current Question</h3>

--- a/imports/ui/pages/professor/run_session.jsx
+++ b/imports/ui/pages/professor/run_session.jsx
@@ -234,20 +234,17 @@ class _RunSession extends Component {
                 }
               </ol>
               <hr />
-              <div className='btn-group btn-group-justified' role='group'>
-                <a href='#' className='btn btn-default btn-sm' onClick={this.prevQuestion}>Previous Question</a>
-                <a href='#' className='btn btn-default btn-sm' onClick={this.nextQuestion}>Next Question</a>
+              <div className='btn-group btn-group-justified bottom-group' role='group'>
+                <a href='#' className='btn btn-default btn-sm' onClick={this.prevQuestion}><span className='glyphicon glyphicon-arrow-left' /> Previous Question</a>
+                <a href='#' className='btn btn-default btn-sm' onClick={this.nextQuestion}>Next Question <span className='glyphicon glyphicon-arrow-right' /></a>
               </div>
             </div>
           </div>
           <div className='ql-main-content' >
-            <h3>Current Question: {q.plainText}</h3>
-            <hr />
             <h3>Results/Stats</h3>
             {<AnswerDistribution question={q} />}
             <div className='clear' />
-            <hr />
-            <h3>Question Preview</h3>
+            <h3 className='m-margin-top'>Question Preview</h3>
             <div className='ql-question-preview'>{ q ? <QuestionDisplay question={q} attempt={currentAttempt} readonly /> : '' }</div>
           </div>
         </div>

--- a/imports/ui/pages/professor/run_session.jsx
+++ b/imports/ui/pages/professor/run_session.jsx
@@ -1,13 +1,11 @@
-/* global confirm  */
 // QLICKER
 // Author: Enoch T <me@enocht.am>
 //
-// manage_course.jsx: page for managing a specific course
+// run_session.jsx: page for managing a currently running session
 
 import React, { Component } from 'react'
 // import ReactDOM from 'react-dom'
-import _ from 'underscore'
-import $ from 'jquery'
+import { _ } from 'underscore'
 
 import { createContainer } from 'meteor/react-meteor-data'
 import DragSortableList from 'react-drag-sortable'
@@ -18,6 +16,7 @@ import { Questions } from '../../../api/questions'
 
 import { QuestionListItem } from '../../QuestionListItem'
 import { QuestionDisplay } from '../../QuestionDisplay'
+import { AnswerDistribution } from '../../AnswerDistribution'
 
 class _RunSession extends Component {
 
@@ -118,6 +117,7 @@ class _RunSession extends Component {
   }
 
   render () {
+    if (this.state.session.status !== 'running') return <div>Session not running</div>
     const current = this.state.session.currentQuestion
     if (this.props.loading || !current) return <div>Loading</div>
 
@@ -132,7 +132,6 @@ class _RunSession extends Component {
     })
 
     const q = this.props.questions[current]
-    const answerDistribution = q.getDistribution()
 
     return (
       <div className='container-fluid ql-manage-session'>
@@ -167,14 +166,7 @@ class _RunSession extends Component {
             <hr />
             <h3>Results/Stats</h3>
             <button className='btn btn-default' onClick={() => this.toggleStats(q._id)}>Show/Hide Stats</button>
-
-            <BarChart
-              width={500} height={200} data={answerDistribution}
-              margin={{top: 5, right: 0, left: -20, bottom: 5}}>
-              <XAxis dataKey='answer' />
-              <YAxis allowDecimals={false} />
-              <Bar dataKey='count' fill='#2FB0E8' label isAnimationActive={false} />
-            </BarChart>
+            <AnswerDistribution question={q} attempt={1} />
 
             <hr />
             <h3>Question Preview</h3>
@@ -193,6 +185,7 @@ export const RunSession = createContainer((props) => {
   const handle = Meteor.subscribe('sessions') &&
     Meteor.subscribe('questions.inSession', props.sessionId) &&
     Meteor.subscribe('questions.library')
+
   const session = Sessions.find({ _id: props.sessionId }).fetch()[0]
   const questionsInSession = Questions.find({ _id: { $in: session.questions || [] } }).fetch()
 

--- a/server/main.js
+++ b/server/main.js
@@ -4,6 +4,7 @@ import '../imports/api/users.js'
 import '../imports/api/courses.js'
 import '../imports/api/sessions.js'
 import '../imports/api/questions.js'
+import '../imports/api/answers.js'
 
 Meteor.startup(() => {
 })


### PR DESCRIPTION
Student answer submissions are now based on an attempted answer for a question. `answers` now have their own collection. 

- answers collection with `answer.addQuestionAnswer` and `answer.update`
- `questions.startAttempt` and `questions.endAttempt` to manage question attempts
- improved CSS and UI for running session
- improved question answer distribution chart with attempt comparison 